### PR TITLE
Fixed OVA/OVF parser and tests

### DIFF
--- a/lib/occi/parser.rb
+++ b/lib/occi/parser.rb
@@ -234,7 +234,7 @@ module Occi
 
 
     def self.calculate_capacity_gb(capacity)
-      capacity_gb = capacity/(2**30)
+      capacity_gb = capacity.to_f/(2**30)
       capacity_gb
     end
 
@@ -346,14 +346,14 @@ module Occi
             case resType.to_s
               # 4 is the ResourceType for memory in the CIM_ResourceAllocationSettingData
               when "4" then
-                OCCI::Log.debug('calculating memory in gb ')
+                Occi::Log.debug('calculating memory in gb ')
                 alloc_units = resource_alloc.xpath("item:AllocationUnits/text()", 'item' => "#{Parser::RASD}").to_s
-                OCCI::Log.debug('allocated units in ovf file: ' + alloc_units)
+                Occi::Log.debug('allocated units in ovf file: ' + alloc_units)
                 alloc_unit_bytes = self.alloc_units_bytes(alloc_units)
                 capacity = self.calculate_capacity_bytes(resource_alloc.xpath("item:VirtualQuantity/text()", 'item' => "#{Parser::RASD}").to_s, alloc_unit_bytes)
                 capacity_gb = self.calculate_capacity_gb(capacity)
-                OCCI::Log.debug('virtual quantity of memory configured in gb: ' + capacity_gb.to_s)
-                compute.attributes.occi!.compute!.memory = capacity_gb.to_s
+                Occi::Log.debug('virtual quantity of memory configured in gb: ' + capacity_gb.to_s)
+                compute.attributes.occi!.compute!.memory = capacity_gb
                 #  compute.attributes.occi!.compute!.memory = resource_alloc.xpath("item:VirtualQuantity/text()", 'item' => "#{Parser::RASD}").to_s.to_i
                 # 3 is the ResourceType for processor in the CIM_ResourceAllocationSettingData
               when "3" then

--- a/spec/occi/parser_spec.rb
+++ b/spec/occi/parser_spec.rb
@@ -8,7 +8,6 @@ describe "Parser" do
     body          = %Q|Category: compute; scheme="http://schemas.ogf.org/occi/infrastructure#"; class="kind"\nX-OCCI-Attribute: occi.compute.cores=2|
     _, collection = Occi::Parser.parse(media_type, body)
     collection.should be_kind_of Occi::Collection
-    jj collection
     compute_resources = collection.resources.select { |resource| resource.kind =='http://schemas.ogf.org/occi/infrastructure#compute' }
     compute_resources.should have(1).compute_resource
     compute_resources.first.attributes.occi!.compute!.cores.should == 2
@@ -38,7 +37,7 @@ describe "Parser" do
     compute_resources = collection.resources.select { |resource| resource.kind == 'http://schemas.ogf.org/occi/infrastructure#compute' }
     compute_resources.should have(1).compute_resource
     compute_resources.first.attributes.occi!.compute!.cores.should == 1
-    compute_resources.first.attributes.occi!.compute!.memory.should == 256
+    compute_resources.first.attributes.occi!.compute!.memory.should == 0.25
   end
 
   it "should parse an OVA container" do
@@ -54,6 +53,6 @@ describe "Parser" do
     compute_resources = collection.resources.select { |resource| resource.kind == 'http://schemas.ogf.org/occi/infrastructure#compute' }
     compute_resources.should have(1).compute_resource
     compute_resources.first.attributes.occi!.compute!.cores.should == 1
-    compute_resources.first.attributes.occi!.compute!.memory.should == 256
+    compute_resources.first.attributes.occi!.compute!.memory.should == 0.25
   end
 end


### PR DESCRIPTION
Commits
- 8bdda2f970
- 00b4e5f867
- 5dbcfbf6fb

broke OVA/OVF parser and rspec tests. They also changed parser's behavior when parsing OVA/OVF. GBs are used as memory units when parsing OVA/OVF and MBs when parsing OCCI JSON. This is confusing since rspec tests now have to use

compute_resources.first.attributes.occi!.compute!.memory.should == 0.25

for OVA/OVF parsing and 

compute_resources.first.attributes.occi!.compute!.memory.should == 256

for OCCI JSON parsing ... not to mention the confusion it causes on the upper levels.

This pull request includes a quick fix, but we should definitely avoid such changes in the future (at least without proper pull requests). How should we proceed? 
