### PR TITLE
Fixes #63, using hash for client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,16 @@ To include the DSL definitions in a class use
 
 To connect to an OCCI endpoint/server (e.g. running on http://localhost:3300/ )
 
-    connect(:http, 'http://localhost:3300',auth||=nil)
+    # defaults
+    options = {
+      :endpoint => "http://localhost:3300/",
+      :auth => {:type => "none"},
+      :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+      :auto_connect => "value", auto_connect => true,
+      :media_type => nil
+    }
+
+    connect(:http, options ||= {})
 
 To get the list of available resource, mixin, entity or link types use
 
@@ -232,7 +241,16 @@ at a time, you should use the OCCI client API directly.
 
 To connect to an OCCI endpoint/server (e.g. running on http://localhost:3300/ )
 
-    client = Occi::Api::Client::ClientHttp.new('http://localhost:3300',auth||=nil)
+    # defaults
+    options = {
+      :endpoint => "http://localhost:3300/",
+      :auth => {:type => "none"},
+      :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+      :auto_connect => "value", auto_connect => true,
+      :media_type => nil
+    }
+
+    client = Occi::Api::Client::ClientHttp.new(options ||= {})
 
 All available categories are automatically registered to the OCCI model during client initialization. You can get them via
 

--- a/bin/occi
+++ b/bin/occi
@@ -60,7 +60,9 @@ end
 # no effect on the non-interactive one
 begin
   Occi::Log.info "Establishing a connection to #{options.endpoint} ..."
-  connect :http, options.endpoint, options.auth, options.log, true, options.media_type
+
+  options.auto_connect = true
+  connect :http, options
 rescue OpenSSL::SSL::SSLError => ssl_ex
   # generic SSL error raised whilst establishing a connection
   # possibly an untrusted server cert or invalid user credentials 

--- a/examples/dsl_example.rb
+++ b/examples/dsl_example.rb
@@ -17,13 +17,22 @@ CA_PATH            = '/etc/grid-security/certificates'
 ENDPOINT           = 'https://localhost:3300'
 
 ## establish a connection
-connect(:http, ENDPOINT,
-        { :type               => "x509",
-          :user_cert          => USER_CERT,
-          :user_cert_password => USER_CERT_PASSWORD,
-          :ca_path            => CA_PATH },
-        { :out   => STDERR,
-          :level => Occi::Log::DEBUG })
+connect(
+  :http,
+  {
+    :endpoint => ENDPOINT,
+    :auth     => {
+      :type               => "x509",
+      :user_cert          => USER_CERT,
+      :user_cert_password => USER_CERT_PASSWORD,
+      :ca_path            => CA_PATH
+    },
+    :log => {
+      :out   => STDERR,
+      :level => Occi::Log::DEBUG
+    }
+  }
+)
 
 puts "\n\nListing all available resource types:"
 resource_types.each do |type|

--- a/examples/x509auth_example.rb
+++ b/examples/x509auth_example.rb
@@ -14,13 +14,19 @@ CA_PATH            = '/etc/grid-security/certificates'
 ENDPOINT           = 'https://localhost:3300'
 
 ## get an OCCI::Api::Client::ClientHttp instance
-client = Occi::Api::Client::ClientHttp.new(ENDPOINT,
-        { :type               => "x509",
-          :user_cert          => USER_CERT,
-          :user_cert_password => USER_CERT_PASSWORD,
-          :ca_path            => CA_PATH },
-        { :out   => STDERR,
-          :level => Occi::Log::DEBUG })
+client = Occi::Api::Client::ClientHttp.new({
+  :endpoint => ENDPOINT,
+  :auth => {
+    :type               => "x509",
+    :user_cert          => USER_CERT,
+    :user_cert_password => USER_CERT_PASSWORD,
+    :ca_path            => CA_PATH
+  },
+  :log => {
+    :out   => STDERR,
+    :level => Occi::Log::DEBUG
+  }
+})
 
 puts "\n\nListing all available resource types:"
 client.get_resource_types.each do |type|

--- a/features/common/step_definitions/common_steps.rb
+++ b/features/common/step_definitions/common_steps.rb
@@ -17,14 +17,14 @@ Given /^category filter : (.*)$/ do |category_filter|
 end
 
 Given /^have an initialize Client$/ do
-  @client = Occi::Api::Client::ClientHttp.new(
-      @endpoint, #141.5.99.69 #11.5.99.82
-      { :type  => "none" },
-      { :out   => "/dev/null",
-        :level => Occi::Log::DEBUG },
-      true,
-      @accept_type#"text/plain,text/occi"
-  )
+  @client = Occi::Api::Client::ClientHttp.new({
+    :endpoint => @endpoint, #141.5.99.69 #11.5.99.82
+    :auth => { :type  => "none" },
+    :log => { :out   => "/dev/null",
+              :level => Occi::Log::DEBUG },
+    :auto_connect => true,
+    :media_type => @accept_type#"text/plain,text/occi"
+  })
 end
 
 Then /^the Client should have the response code (.*)$/ do |response_code|

--- a/lib/occi/api/client/client_amqp.rb
+++ b/lib/occi/api/client/client_amqp.rb
@@ -67,28 +67,38 @@ module Occi
       # from the server.
       #
       # @example
-      #    Occi::Api::Client::ClientAmqp.new # => #<Occi::Api::Client::ClientAmqp>
+      #    options = {
+      #      :endpoint => "http://localhost:3300/",
+      #      :auth => {:type => "none"},
+      #      :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+      #      :media_type => "text/plain"
+      #    }
       #
-      # @param [String] endpoint URI
-      # @param [Hash] auth options in a hash
-      # @param [Hash] logging options in a hash
-      # @param [Boolean] enable autoconnect
-      # @param [String] media type identifier
+      #    Occi::Api::Client::ClientAmqp.new options # => #<Occi::Api::Client::ClientAmqp>
+      #
+      # @param [Hash] options, for available options and defaults see examples
       # @return [Occi::Api::Client::ClientAmqp] client instance
-      def initialize(endpoint = "http://localhost:3000/", auth_options = { :type => "none" },
-          log_options = { :out => STDERR, :level => Occi::Log::WARN, :logger => nil },
-          media_type = "text/plain")
+      def initialize(options = {})
+
+        defaults = {
+            :endpoint => "http://localhost:3300/",
+            :auth => {:type => "none"},
+            :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+            :media_type => "text/plain"
+        }
+
+        options = defaults.merge options
 
         # check the validity and canonize the endpoint URI
-        prepare_endpoint endpoint
+        prepare_endpoint options[:endpoint]
 
         # set Occi::Log
-        set_logger log_options
+        set_logger options[:log]
 
         # pass auth options to HTTParty
-        change_auth auth_options
+        change_auth options[:auth]
 
-        @media_type = media_type
+        @media_type = options[:media_type]
 
         Occi::Log.debug("Media Type: #{@media_type}")
 
@@ -96,7 +106,7 @@ module Occi
 
         Thread.new { run }
 
-        print "Waiting for connection amqp ..."
+        Occi::Log.debug("Waiting for connection amqp ...")
 
         #TODO find a better solution for the thread issue
         while(!@thread_error && !@connected)

--- a/lib/occi/api/client/client_http.rb
+++ b/lib/occi/api/client/client_http.rb
@@ -75,33 +75,46 @@ module Occi
         # from the server.
         #
         # @example
-        #    Occi::Api::Client::ClientHttp.new # => #<Occi::Api::Client::ClientHttp>
+        #    options = {
+        #      :endpoint => "http://localhost:3300/",
+        #      :auth => {:type => "none"},
+        #      :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+        #      :auto_connect => "value", auto_connect => true,
+        #      :media_type => nil
+        #    }
         #
-        # @param [String] endpoint URI
-        # @param [Hash] auth options in a hash
-        # @param [Hash] logging options in a hash
-        # @param [Boolean] enable autoconnect
-        # @param [String] media type identifier
+        #    Occi::Api::Client::ClientHttp.new options # => #<Occi::Api::Client::ClientHttp>
+        #
+        # @param [Hash] options, for available options and defaults see examples
         # @return [Occi::Api::Client::ClientHttp] client instance
-        def initialize(endpoint = "http://localhost:3000/", auth_options = {:type => "none"},
-                       log_options = {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
-                       auto_connect = true, media_type = nil)
+        def initialize(options = {})
+
+          defaults = {
+            :endpoint => "http://localhost:3300/",
+            :auth => {:type => "none"},
+            :log => {:out => STDERR, :level => Occi::Log::WARN, :logger => nil},
+            :auto_connect => true,
+            :media_type => nil
+          }
+
+          options = defaults.merge options
+
           # set Occi::Log
-          set_logger log_options
+          set_logger options[:log]
 
           # pass auth options to HTTParty
-          change_auth auth_options
+          change_auth options[:auth]
 
           # check the validity and canonize the endpoint URI
-          prepare_endpoint endpoint
+          prepare_endpoint options[:endpoint]
 
           # get accepted media types from HTTParty
           set_media_type
 
           # force media_type if provided
-          if media_type
-            self.class.headers 'Accept' => media_type
-            @media_type = media_type
+          if options[:media_type]
+            self.class.headers 'Accept' => options[:media_type]
+            @media_type = options[:media_type]
           end
 
           Occi::Log.debug("Media Type: #{@media_type}")
@@ -112,7 +125,7 @@ module Occi
           set_model
 
           # auto-connect?
-          @connected = auto_connect
+          @connected = options[:auto_connect]
         end
 
         # Creates a new resource instance, resource should be specified

--- a/spec/occi/api/client/client_amqp_spec.rb
+++ b/spec/occi/api/client/client_amqp_spec.rb
@@ -23,9 +23,12 @@ module Occi
 
 =begin
       before(:all) do
-        @client = Occi::Api::Client::ClientAmqp.new("http://localhost:9292/", auth_options = { :type => "none" },
-                                            log_options = { :out => STDERR, :level => Occi::Log::WARN, :logger => nil },
-                                            media_type = "application/occi+json")
+        @client = Occi::Api::Client::ClientAmqp.new({
+          :endpoint => "http://localhost:9292/",
+          :auth => { :type => "none" },
+          :log => { :out => STDERR, :level => Occi::Log::WARN, :logger => nil },
+          :media_type => "application/occi+json"
+        })
       end
 
       it "initialize and connect client" do

--- a/spec/occi/api/client/client_http_spec.rb
+++ b/spec/occi/api/client/client_http_spec.rb
@@ -11,14 +11,14 @@ module Occi
       context "using media type text/plain" do
 
         before(:each) do
-          @client = Occi::Api::Client::ClientHttp.new(
-           'https://localhost:3300',
-           { :type  => "none" },
-           { :out   => "/dev/null",
-             :level => Occi::Log::DEBUG },
-           true,
-           "text/plain,text/occi"
-          )
+          @client = Occi::Api::Client::ClientHttp.new({
+           :endpoint => 'https://localhost:3300',
+           :auth => { :type  => "none" },
+           :log => { :out   => "/dev/null",
+                     :level => Occi::Log::DEBUG },
+           :auto_connect => true,
+           :media_type => "text/plain,text/occi"
+          })
         end
 
         after(:each) do
@@ -189,14 +189,14 @@ module Occi
       context "using media type application/occi+json" do
 
         before(:each) do
-          #@client = Occi::Api::ClientHttp.new(
-          #  'https://localhost:3300',
-          #  { :type  => "none" },
-          #  { :out   => "/dev/null",
-          #    :level => Occi::Log::DEBUG },
-          #  true,
-          #  "application/occi+json"
-          #)
+          #@client = Occi::Api::ClientHttp.new({
+          #  :endpoint => 'https://localhost:3300',
+          #  :auth => { :type  => "none" },
+          #  :log => { :out   => "/dev/null",
+          #            :level => Occi::Log::DEBUG },
+          #  :auto_connect => true,
+          #  :media_type => "application/occi+json"
+          #})
         end
 
         it "establishes connection"


### PR DESCRIPTION
Making ClientHttp and ClientAmqp more flexible and preventing future compatibility problems.

**DONE**
