### PR TITLE
[bugfix] Fixed OpenStruct merge issue

### DIFF
--- a/lib/occi/api/client/client_amqp.rb
+++ b/lib/occi/api/client/client_amqp.rb
@@ -87,6 +87,7 @@ module Occi
             :media_type => "text/plain"
         }
 
+        options = options.marshal_dump if options.is_a? OpenStruct
         options = defaults.merge options
 
         # check the validity and canonize the endpoint URI

--- a/lib/occi/api/client/client_http.rb
+++ b/lib/occi/api/client/client_http.rb
@@ -97,6 +97,7 @@ module Occi
             :media_type => nil
           }
 
+          options = options.marshal_dump if options.is_a? OpenStruct
           options = defaults.merge options
 
           # set Occi::Log


### PR DESCRIPTION
OpenStruct options have to be marshalled before attempting
a merge with defaults. This is a bin/occi-related issue and
wasn't covered by rspec tests (WIP).
