### PR TITLE
Fixes #62, normalize endpoint URI

### DIFF
--- a/lib/occi/bin/occi_opts.rb
+++ b/lib/occi/bin/occi_opts.rb
@@ -82,10 +82,7 @@ Examples:
                   "--endpoint URI",
                   String,
                   "OCCI server URI, defaults to '#{options.endpoint}'") do |endpoint|
-            # Do some basic validation of the endpoint URI
-            URI(endpoint)
-
-            options.endpoint = endpoint
+            options.endpoint = URI(endpoint).to_s
           end
 
           opts.on("-n",

--- a/lib/occi/version.rb
+++ b/lib/occi/version.rb
@@ -1,3 +1,3 @@
 module Occi
-  VERSION = "3.1.0.alpha.1" unless defined?(::Occi::VERSION)
+  VERSION = "3.1.0.beta.1" unless defined?(::Occi::VERSION)
 end


### PR DESCRIPTION
- Performs basic URI validation (no spaces, special characters, etc.)
- Normalizes default port numbers (removes 80, 443 from http(s) links)
- Version bump to 3.1.0.beta.1
