### PR TITLE
Added basic support for OS Keystone

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ To describe available resources use
 
 To describe specific resources use
 
-    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource https://<ENDPOINT>:<PORT>/compute/<OCCI_ID> --auth x509
-    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource https://<ENDPOINT>:<PORT>/storage/<OCCI_ID> --auth x509
-    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource https://<ENDPOINT>:<PORT>/network/<OCCI_ID> --auth x509
+    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource /compute/<OCCI_ID> --auth x509
+    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource /storage/<OCCI_ID> --auth x509
+    occi --endpoint https://<ENDPOINT>:<PORT>/ --action describe --resource /network/<OCCI_ID> --auth x509
 
 To list available OS templates or Resource templates use
 
@@ -113,11 +113,11 @@ To describe a specific OS template or Resource template use
 
 To create a compute resource with mixins use
 
-    occi --endpoint https://<ENDPOINT>:<PORT>/ --action create --resource compute --mixin os_tpl#debian6 --mixin resource_tpl#small --resource-title "My rOCCI VM" --auth x509
+    occi --endpoint https://<ENDPOINT>:<PORT>/ --action create --resource compute --mixin os_tpl#debian6 --mixin resource_tpl#small --attributes title="My rOCCI VM" --auth x509
 
 To delete a compute resource use
 
-    occi --endpoint https://<ENDPOINT>:<PORT>/ --action delete --resource https://<ENDPOINT>:<PORT>/compute/<OCCI_ID> --auth x509
+    occi --endpoint https://<ENDPOINT>:<PORT>/ --action delete --resource /compute/<OCCI_ID> --auth x509
 
 ### Client scripting
 
@@ -145,7 +145,7 @@ For X.509 auth use
     auth.user_cert_password = 'MyPassword'
     auth.ca_path = '/Path/To/root-certificates'
 
-For keystone auth use
+**Deprecated:** For keystone auth use
 
     auth = Hashie::Mash.new
     auth.type = 'keystone'
@@ -225,15 +225,15 @@ To create a new compute resource use
 
 To get a description of a specific resource use
 
-    describe "https://<ENDPOINT>:<PORT>/compute/<OCCI_ID>"
-    describe "https://<ENDPOINT>:<PORT>/storage/<OCCI_ID>"
-    describe "https://<ENDPOINT>:<PORT>/network/<OCCI_ID>"
+    describe "/compute/<OCCI_ID>"
+    describe "/storage/<OCCI_ID>"
+    describe "/network/<OCCI_ID>"
 
 To delete a specific resource use
 
-    delete "https://<ENDPOINT>:<PORT>/compute/<OCCI_ID>"
-    delete "https://<ENDPOINT>:<PORT>/storage/<OCCI_ID>"
-    delete "https://<ENDPOINT>:<PORT>/network/<OCCI_ID>"
+    delete "/compute/<OCCI_ID>"
+    delete "/storage/<OCCI_ID>"
+    delete "/network/<OCCI_ID>"
 
 #### API
 If you need low level access to parts of the OCCI client or need to use more than one instance
@@ -306,15 +306,15 @@ To create a new compute resource use
 
 To get a description of a specific resource use
 
-    client.describe "https://<ENDPOINT>:<PORT>/compute/<OCCI_ID>"
-    client.describe "https://<ENDPOINT>:<PORT>/storage/<OCCI_ID>"
-    client.describe "https://<ENDPOINT>:<PORT>/network/<OCCI_ID>"
+    client.describe "/compute/<OCCI_ID>"
+    client.describe "/storage/<OCCI_ID>"
+    client.describe "/network/<OCCI_ID>"
 
 To delete a specific resource use
 
-    client.delete "https://<ENDPOINT>:<PORT>/compute/<OCCI_ID>"
-    client.delete "https://<ENDPOINT>:<PORT>/storage/<OCCI_ID>"
-    client.delete "https://<ENDPOINT>:<PORT>/network/<OCCI_ID>"
+    client.delete "/compute/<OCCI_ID>"
+    client.delete "/storage/<OCCI_ID>"
+    client.delete "/network/<OCCI_ID>"
 
 #### Logging
 
@@ -386,6 +386,13 @@ The OCCI gem includes all OCCI Core classes necessary to handly arbitrary OCCI o
 
 Changelog
 ---------
+
+### Version 3.1
+* added basic OS Keystone support
+* added support for PKCS12 credentials for X.509 authN
+* updated templates for plain output formatting
+* minor client API changes
+* several bugfixes
 
 ### Version 3.0
 

--- a/features/cassettes/Create_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Create_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:53 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFOTdkZDQ1N2ZiYjdmMjE4NDgzNjMy%0AMzE0ZGI3YjRjOGIwZjMyNTY4ODRkZGVhNjE3NWM4OWI2MDRkNzJiMmFjOUki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--222744ef8a6fa387cf796b175ba56ec13ea1fa93;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:46 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Create_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Create_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:41 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:42 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFNjFhMGNmNzdmMDUyOWRmMTBlNWRj%0AOGM2NjE0YWZmMGJjZTYxNDliYjY1OTVhM2E0MjcwNmJiMzJiM2Y2MjY1N0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--c0f98b65169ac2a7e9b2849d1315a7649a2c4e32;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Delete_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Delete_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:53 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFYjk4Zjc0NTRhMGUxN2VkMWJhYWEz%0AY2E0OTFjMWE0NWUxZjIwYzBlNWU2MjUyMzYxZGI5MjU4MGZhMjc0OWJhNkki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--4ac5e72fdf64d3b35dbbe65e7c38da3d3311c964;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:46 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Delete_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Delete_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:41 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:42 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFOGIwOTNjN2I2YTRhYWNmYWMzOTE1%0ANGJiODUxNTNjOTUyNThkNzM0NjFjOGNiYjA3ZDM4ZDYwOWVjZjAxY2M4NUki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--2a011f27068ccd94899403b26651e4fcfde15436;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__application_json_200_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__application_json_200_.yml
@@ -170,4 +170,84 @@ http_interactions:
         network"}]}'
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:42 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:42 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFN2E4NTRmNjhmNjU1YjJiNjliOGZk%0AYTI2NDhkN2RjMzE1NGY4MmZlYmQzYjI1ZGUzNjcyNDVkOWFiNWUxYzMwOUki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--f827e521323b9a3df64188e870b7accd57c45170;
+        path=/; HttpOnly
+      Content-Length:
+      - '3444'
+      Status:
+      - '200'
+      Content-Type:
+      - application/json;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"resources":[{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"48e7c51c-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"6c706278-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"7582ffc4-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8eb0deb2-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8efa93e0-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"49cbeaee-5b1d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"c87fa76c-5b1e-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"1cc544b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"38e2a6b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}}]}'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:42 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFMDU2MTY4M2VjMjcxMGY1ZGEwOTJi%0AYTI4YWIwZjc1YmIwYTY5ZjE1NmIzYmY4MTA3NjY2MWY0OGMzZTE4MjRhN0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--a0539607471f06a5405858228fc124c1744ee77e;
+        path=/; HttpOnly
+      Content-Length:
+      - '3444'
+      Status:
+      - '200'
+      Content-Type:
+      - application/json;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"resources":[{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"48e7c51c-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"6c706278-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"7582ffc4-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8eb0deb2-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8efa93e0-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"49cbeaee-5b1d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"c87fa76c-5b1e-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"1cc544b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"38e2a6b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}}]}'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__application_json_200_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__application_json_200_.yml
@@ -250,4 +250,84 @@ http_interactions:
       string: ! '{"resources":[{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"48e7c51c-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"6c706278-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"7582ffc4-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8eb0deb2-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"8efa93e0-5a7d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"49cbeaee-5b1d-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"c87fa76c-5b1e-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"1cc544b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}},{"kind":"http://schemas.ogf.org/occi/infrastructure#compute","actions":["http://schemas.ogf.org/occi/infrastructure/compute/action#stop","http://schemas.ogf.org/occi/infrastructure/compute/action#restart","http://schemas.ogf.org/occi/infrastructure/compute/action#suspend"],"attributes":{"occi":{"core":{"id":"38e2a6b2-5b1f-11e2-a300-fa163e16d22f"},"compute":{"state":"active"}}}}]}'
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:53 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFOWU5YjM0OGFmMTc4ODBhMTY1MjYx%0ANTJjZTQ2NzZjMjE4YmY3ODExNDkxZjU5OThmOTRmNDU1NDFjMTZjZmM2ZEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--197a67fdc50a0952ca986c13e213ec8892b4beff;
+        path=/; HttpOnly
+      Content-Length:
+      - '3444'
+      Status:
+      - '200'
+      Content-Type:
+      - application/json;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:46 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:54 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFY2NkMGVmNDI4ZGRmMmEyODIyYjAx%0AOTQ5MDdjZTljZjNjMDIwNDZmMmFhMmVhYjBkZGVlM2EzODhjY2NhNzExOEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--199003590da3d7ad28f69a8be2c88e694c6f479c;
+        path=/; HttpOnly
+      Content-Length:
+      - '3444'
+      Status:
+      - '200'
+      Content-Type:
+      - application/json;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:46 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_.yml
@@ -442,4 +442,88 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:54 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFYzFmM2UxZTlmYzBhM2U4OWYzNDM3%0AZjZhOWVkNTkxNjdkMDBmMGQyMTlhNjg0Njc0ZmUyZTEwYzJjYjhkYjhkOEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--e4f3ebb5a4f67c116d365f9d2d48507f6140ab98;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:47 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:54 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFYWE4ZGQ1ODg3MmY4YmY0MWU5Njk1%0ANDViM2I1N2M0MTM5ZjQzMTcyZWQzNjNhYzg3MzJjNTE1NTkzNWM3Y2QyOEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--0fdb677cfa381297340297b5f143116fb5171ff5;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:47 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_.yml
@@ -322,4 +322,124 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:42 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:43 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFY2Y2ZDQxNTBkNmY3YmUwNDQ3YzI5%0AZmJmYjNjZGJiMTM1NmMwMDkzNjUzN2UxNGQ5ODMxYTBhMTVkMWI2NDU3ZUki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--28b0beea7802c8083337ceb6e63b1ade57e418db;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:35 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:43 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFMGUwMmJhMzkwNzllNmY3MjI4Zjkz%0AN2VkMDAzY2E0ZDIwNGE4NDk3YzhkZjc2NDU3YTFhZDllNjQ3MTQ5YjU5Nkki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--0662384d0128610634d8cdc9bc75698b26d7aa66;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_action_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_action_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:43 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:43 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFMmU0Y2NiMGQ5YzJhOTVhZGFhNDU5%0AMDA3ODMyMjlmOWEzZjhjOWVlYTY0NTZjN2IyYTg3MmZhYjk1OWE0MDQxN0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--6f6f618f7f166d4a0758636dd6fb0f6d19b29e38;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_action_.yml
+++ b/features/cassettes/Discovery_Interface/Retrieving_all_OCCI_Categories_supported_by_the_OCCI_Server/_http_http___141_5_99_69__text_plain_200_action_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:54 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFMzlhOTdjYjQxNGViNWE2MmE0YjJk%0AOTMwZTIwMWEwOGRkMjUyMmE5YjgwZjAzNzU3MDM1NjZmNDIyZDhkNWExNEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--9b0b4234d587b059fff353f54131d4d28dab6a38;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:47 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Miscellaneous_operation_on_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Miscellaneous_operation_on_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:43 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:43 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFYWI4ZGQ2OGY5ZDFiMTUxZTQ3NWQ5%0ANDQ4Zjg2ZmVmZTM0ZTMyOTlhMWYyMWY5YmEyNmNhMTg1YjA4ZTMyYmQzNUki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--7f00828c64a9a1b76af0c1199f58e0292cdb0bfa;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Miscellaneous_operation_on_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Miscellaneous_operation_on_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:54 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFMGExMWVlMjYwMzQyNzc5MzVlOGZm%0AMzgyZTIyYjFhM2UyNDBmODgyOGE4OTdlZWE0ZmU3YTdjNWY4YjZmZDg0N0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--a3fe81e6991f7f493ec81041aca0d9a3c59e528b;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:47 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Read_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Read_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:43 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:43 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFYjBiYTBjOWQyZTNjYzM5YjU3NjAy%0AOTVjNDMxNjFjNjQ2MjU1NjAzNjZlOGQzMGY3OGE1YzQ1ODg4ZmY0ZGVlMkki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--231de3379ec76c61d9af3835c67bc585c534c261;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Read_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Read_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:55 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFNDc5MjRjNmMzMWUxMGEyYjk2NDY0%0AMjkyNTllYjExYzEyOWM1NzcwNjE0NGNjNTRlMzg3YjJlNjE5YjlhZWQ4Nkki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--e28fbcd2de0277dbe9ff148606f7f4059cefb8cf;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:48 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Update_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Update_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -243,4 +243,46 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
+- request:
+    method: head
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 15:27:55 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFOWIxY2FkNmM0ODZkY2U5MzllYTZk%0ANDY3ZjgwNzRjNmI1NjA5NGRhNjBkNWZlYzg2MTA4NTk1OTIwZmIxNmRkMEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--b576238584753a3c874e52e73b6bb06a34881845;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 15:27:48 GMT
 recorded_with: VCR 2.4.0

--- a/features/cassettes/Update_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
+++ b/features/cassettes/Update_an_OCCI_Resource/_http_http___141_5_99_69__text_plain_201_.yml
@@ -183,4 +183,64 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 13:52:44 GMT
+- request:
+    method: get
+    uri: http://141.5.99.69/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 12 Mar 2013 13:29:44 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.18
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZjhhYWFiY2M4NzI1YmM5ZDAxOTM4%0AOTlkMmY1YzQwMzIwNzU4NGZkMGI2MGQ4NTdjNTE3NjhjNzVmYTAzZGY0NEki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--ed98c412bd15e6cbf4678ae0539ff96b547ab216;
+        path=/; HttpOnly
+      Content-Length:
+      - '738'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! 'X-OCCI-Location:  http://141.5.99.69/compute/48e7c51c-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/6c706278-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/7582ffc4-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8eb0deb2-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/8efa93e0-5a7d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/49cbeaee-5b1d-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/c87fa76c-5b1e-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/1cc544b2-5b1f-11e2-a300-fa163e16d22f
+
+        X-OCCI-Location:  http://141.5.99.69/compute/38e2a6b2-5b1f-11e2-a300-fa163e16d22f
+
+'
+    http_version: 
+  recorded_at: Tue, 12 Mar 2013 13:29:36 GMT
 recorded_with: VCR 2.4.0

--- a/lib/occi/version.rb
+++ b/lib/occi/version.rb
@@ -1,3 +1,3 @@
 module Occi
-  VERSION = "3.1.0.beta.2" unless defined?(::Occi::VERSION)
+  VERSION = "3.1.0.beta.3" unless defined?(::Occi::VERSION)
 end

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_compute_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_compute_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_network_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_network_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_storage_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/creates_a_new_storage_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_compute_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_compute_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_network_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_network_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_storage_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deletes_a_storage_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deploys_an_instance_based_on_OVF_OVA_file.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deploys_an_instance_based_on_OVF_OVA_file.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deploys_an_instance_based_on_OVF_OVA_file.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/deploys_an_instance_based_on_OVF_OVA_file.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_all_available_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_all_available_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_all_available_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_all_available_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_compute_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_compute_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_compute_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_compute_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_network_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_network_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_network_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_network_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_os_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_os_tpl_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_os_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_os_tpl_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_resource_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_resource_tpl_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_resource_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_resource_tpl_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_storage_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_storage_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_storage_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/describes_storage_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/establishes_connection.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/establishes_connection.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/establishes_connection.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/establishes_connection.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_identifier.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_identifier.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_name.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_compute_resource_using_type_name.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_identifier.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_identifier.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_name.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_network_resource_using_type_name.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_identifier.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_identifier.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_identifier.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_name.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_name.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/instantiates_a_storage_resource_using_type_name.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_type_identifiers.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_type_identifiers.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_types.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_entity_types.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_type_identifiers.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_type_identifiers.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_types.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_link_types.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_type_identifiers.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_type_identifiers.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_types.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixin_types.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_type_identifiers.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_type_identifiers.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_type_identifiers.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_types.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_types.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_all_available_resource_types.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_compute_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_compute_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_compute_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_compute_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_network_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_network_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_network_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_network_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_os_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_os_tpl_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_os_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_os_tpl_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_resource_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_resource_tpl_mixins.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_resource_tpl_mixins.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_resource_tpl_mixins.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_storage_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_storage_resources.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_storage_resources.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/lists_storage_resources.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/refreshes_its_model.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/refreshes_its_model.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:
@@ -219,6 +263,50 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 10 Jan 2013 17:45:43 GMT
+- request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
 - request:
     method: get
     uri: https://localhost:3300/-/

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/refreshes_its_model.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/refreshes_its_model.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII
@@ -264,7 +264,7 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 10 Jan 2013 17:45:43 GMT
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_compute_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_compute_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_compute_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_network_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_network_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_network_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_storage_resource.yml
@@ -1,6 +1,50 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://localhost:3300/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/plain,text/occi;q=0.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 10 Jan 2013 17:44:39 GMT
+      Server:
+      - Apache/2.2.20 (Ubuntu)
+      X-Powered-By:
+      - Phusion Passenger (mod_rails/mod_rack) 3.0.12
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept:
+      - application/occi+json,application/json,text/plain,text/uri-list,application/xml,text/xml,application/occi+xml,text/occi
+      Set-Cookie:
+      - GRIDHTTP_PASSCODE=ec9b4b21351052e5aPTUJs; domain=localhost; path=/;
+        secure
+      - rack.session=BAh7B0kiD3Nlc3Npb25faWQGOgZFRiJFZTIyZmM5ZmI2OTliY2JiZWQyMjYz%0AN2IyNTQ3NjMyMDkxYTFkNWVhOGIwYjVkYTNhYTllMTYyYjdkZTZiMzhkY0ki%0ADXRyYWNraW5nBjsARnsISSIUSFRUUF9VU0VSX0FHRU5UBjsARiItZGEzOWEz%0AZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUND%0ARVBUX0VOQ09ESU5HBjsARiItZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2%0AMDE4OTBhZmQ4MDcwOUkiGUhUVFBfQUNDRVBUX0xBTkdVQUdFBjsARiItZGEz%0AOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOQ%3D%3D%0A--24c9906d0e0c02c6976b065151f161a7e299022a;
+        path=/; HttpOnly
+      Content-Length:
+      - '294'
+      Status:
+      - '200'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/plain;charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 17:44:39 GMT
+- request:
     method: head
     uri: https://localhost:3300/
     body:

--- a/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_storage_resource.yml
+++ b/spec/cassettes/Occi_Api_Client_ClientHttp/using_media_type_text_plain/triggers_an_action_on_a_storage_resource.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://localhost:3300/
     body:
       encoding: US-ASCII

--- a/spec/occi/api/client/client_http_spec.rb
+++ b/spec/occi/api/client/client_http_spec.rb
@@ -22,7 +22,7 @@ module Occi
         end
 
         after(:each) do
-          @client.logger.close
+          @client.logger.close if @client && @client.logger
         end
 
         it "establishes connection" do


### PR DESCRIPTION
- using `www-authenticate` HTTP header
- only basic/digest and VOMS X.509 authN is supported
