### PR TITLE
Fix Occi modul misspelling

### DIFF
--- a/lib/occi/core/entity.rb
+++ b/lib/occi/core/entity.rb
@@ -89,7 +89,7 @@ module OCCI
       # @param [OCCI::Model] model representation of the OCCI model to check the attributes against
       def check(model)
         raise "No kind defined" unless @kind
-        definitions = Occi::Core::Attributes.new
+        definitions = OCCI::Core::Attributes.new
         definitions.merge!(model.get_by_id(@kind).attributes)
         @mixins.each do |mixin_id|
           mixin = model.get_by_id(mixin_id)


### PR DESCRIPTION
- Occi Module must be written with uppercase
